### PR TITLE
Updated composer for Guzzle 7 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "league/flysystem": "^1.0.20",
-        "guzzlehttp/guzzle": "~6.0"
+        "guzzlehttp/guzzle": "~7.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.1"


### PR DESCRIPTION
Hi Chris,

I wanted to help you support Guzzle 7, what I did was I bumped the Guzzle version to `~7.0` and ran the tests and everything was still green. I know this is not the right branch but your master branch is completely different, So feel free to close this PR and do this 5 min fix yourself, no feelings will be hurt 😄 

I made this PR because of this issue: https://github.com/twistor/flysystem-guzzle/issues/1
I would love to check Statamic out on the just-released Laravel 8 but Laravel 8 requires Guzzle 7 and Statamic uses your Guzzle 6 version.

![image](https://user-images.githubusercontent.com/6010509/92640088-0b547500-f2dd-11ea-9f59-135e419faadd.png)


